### PR TITLE
Make JavaScript always use judge environment settings (remove STRICT_MODE)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,12 +73,13 @@ makefileで管理（`/root/lib/.support/makefile`へのシンボリックリン�
 - C++: GCC 15.2.0 C++23 (language ID: 5001)
 - Ruby: 3.4.5 (language ID: 5018) - judge環境と同じオプションで実行
 - **Elixir: 1.18.4 (OTP 28.0.2) (language ID: 5085) - 常にMix releaseでビルド（Judge環境と同じ）**
-- JavaScript: Node.js 22.19.0
+- **JavaScript: Node.js 22.19.0 (language ID: 5083) - 常にjudge環境設定（64MBスタック）で実行**
 - Rust: 1.87.0 (未対応)
 
 **注意**:
 - Java は `am t .java` でも `am ts .java` でも常に `/judge` ディレクトリ方式（Judge 環境と同じ）でビルド・実行されます。問題ディレクトリに `.class` ファイルが生成されないため、クリーンな開発環境を維持できます。
 - Elixir は `am t .ex` でも `am ts .ex` でも常に Mix release（judge 環境と同じ方式）でビルドされます。ビルド時間が短いため、開発効率とjudge環境との完全一致を両立できます。
+- JavaScript は `am t .js` で常に64MBスタックサイズ（judge 環境と同じ）で実行されます。デフォルトのNode.jsスタック（約1MB）と異なり、再帰処理でのスタックオーバーフローを防ぎます。
 
 ### テンプレート設定
 `atcoder-cli-nodejs/config.json`の`default-template`で指定:

--- a/lib/.support/makefile
+++ b/lib/.support/makefile
@@ -131,16 +131,10 @@ $(TARGET): $(SRC)
 OJ_SFLAGS = -l 5001
 else
 ifeq ($(PROG),javascript)
-# JavaScript
+# JavaScript - Always use judge environment settings
 SRC = Main.js
 TARGET =
-ifeq ($(STRICT_MODE),1)
-# Strict mode: use wrapper script with dynamic stack sizing (KB)
 RUN_TEST = sh $(HOME)/lib/node.sh 65536 $(SRC)
-else
-# Simple mode: basic execution
-RUN_TEST = $(NODE) $(SRC) ONLINE_JUDGE ATCODER
-endif
 # JavaScript (Node.js 23.5.0)
 OJ_SFLAGS = -l 5083
 else


### PR DESCRIPTION
## Summary

Closes #75

JavaScriptの実行を常にjudge環境設定（64MBスタック）で行うようにし、STRICT_MODEの分岐を削除しました。Issue #73 (Java) と同様のアプローチで、ローカル環境とjudge環境の一貫性を向上させます。

## Changes

### makefile の変更
- `STRICT_MODE` の条件分岐を削除
- 常に `sh $(HOME)/lib/node.sh 65536 $(SRC)` を実行（64MBスタック）
- シンプルモード（デフォルトの約1MBスタック）を削除

### CLAUDE.md の更新
- JavaScript実行方式をドキュメント化
- judge環境設定を常に使用することを明記
- 注意事項にJavaScriptの説明を追加

## Test Results

abc428/aで動作確認済み:

```
[INFO] 3 cases found
[SUCCESS] AC (sample-1, 0.024832 sec)
[SUCCESS] AC (sample-2, 0.022985 sec)
[SUCCESS] AC (sample-3, 0.022157 sec)
[SUCCESS] test success: 3 cases
```

実行コマンド: `sh /root/lib/node.sh 65536 Main.js`

## Benefits

1. **Judge環境との一貫性**: ローカルとオンラインジャッジで同じ設定
2. **スタックオーバーフローの防止**: 再帰処理で十分なスタックサイズを確保
3. **設定の簡素化**: STRICT_MODEの管理が不要に
4. **開発体験の向上**: Java (#73) やElixirと同じパターンで統一

## Related

- Follows the same pattern as #73 (Java /judge directory)
- Part of the effort to standardize language execution across the project