### PR TITLE
Update C++ build to use /judge directory pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,15 +70,16 @@ makefileで管理（`/root/lib/.support/makefile`へのシンボリックリン�
 #### 言語バージョンと実行方式
 - **Java: OpenJDK 23.0.1 (language ID: 5005) - 常に/judgeディレクトリでコンパイル・実行（Judge環境と同じ）**
 - Python: CPython 3.13.7 (language ID: 5055) - judge環境と同じオプションで実行
-- C++: GCC 15.2.0 C++23 (language ID: 5001)
+- **C++: GCC 15.2.0 C++23 (language ID: 5001) - 常に/judgeディレクトリでコンパイル・実行（Judge環境と同じ）**
 - Ruby: 3.4.5 (language ID: 5018) - judge環境と同じオプションで実行
 - **Elixir: 1.18.4 (OTP 28.0.2) (language ID: 5085) - 常にMix releaseでビルド（Judge環境と同じ）**
 - **JavaScript: Node.js 22.19.0 (language ID: 5083) - 常にjudge環境設定（64MBスタック）で実行**
 - Rust: 1.87.0 (未対応)
 
 **注意**:
-- Java は `am t .java` でも `am ts .java` でも常に `/judge` ディレクトリ方式（Judge 環境と同じ）でビルド・実行されます。問題ディレクトリに `.class` ファイルが生成されないため、クリーンな開発環境を維持できます。
-- Elixir は `am t .ex` でも `am ts .ex` でも常に Mix release（judge 環境と同じ方式）でビルドされます。ビルド時間が短いため、開発効率とjudge環境との完全一致を両立できます。
+- Java は `am t .java` で常に `/judge` ディレクトリ方式（Judge 環境と同じ）でビルド・実行されます。問題ディレクトリに `.class` ファイルが生成されないため、クリーンな開発環境を維持できます。
+- C++ は `am t .cpp` で常に `/judge` ディレクトリ方式（Judge 環境と同じ）でコンパイル・実行されます。問題ディレクトリに `a.out` が生成されないため、クリーンな開発環境を維持できます。
+- Elixir は `am t .ex` で常に Mix release（judge 環境と同じ方式）でビルドされます。ビルド時間が短いため、開発効率とjudge環境との完全一致を両立できます。
 - JavaScript は `am t .js` で常に64MBスタックサイズ（judge 環境と同じ）で実行されます。デフォルトのNode.jsスタック（約1MB）と異なり、再帰処理でのスタックオーバーフローを防ぎます。
 
 ### テンプレート設定

--- a/lib/.support/makefile
+++ b/lib/.support/makefile
@@ -102,32 +102,16 @@ RUN_TEST = $(PYTHON) -X int_max_str_digits=0 $(SRC)
 OJ_SFLAGS = -l 5055
 else
 ifeq ($(PROG), c++)
-# C++
+# C++ - Always use /judge directory (same as Judge environment)
 SRC = Main.cpp
-TARGET = $(CPPTARGET)
-
-# Using base flags from CFLAGS (line 50): -std=gnu++20
-CPPFLAGS = $(CFLAGS)
-LDFLAGS =
-
-# Strict mode: AtCoder judge environment settings
-ifeq ($(STRICT_MODE),1)
-# Optimization flags
-CPPFLAGS += -O2 -Wall -Wextra
-# constexpr limits
-CPPFLAGS += -fconstexpr-depth=1024 -fconstexpr-loop-limit=524288 -fconstexpr-ops-limit=2097152
-# Optimization techniques
-CPPFLAGS += -flto=auto -march=native
-# Parallel processing
-CPPFLAGS += -pthread -fopenmp
-# Note: Boost/GMP/GMPXX linking requires container image with these libraries
-# LDFLAGS = -lboost_system -lboost_filesystem -lgmp -lgmpxx
-endif
-
-RUN_TEST = ./$(CPPTARGET)
+JUDGEDIR = /judge
+TARGET = $(JUDGEDIR)/a.out
+RUN_TEST = $(JUDGEDIR)/a.out
 $(TARGET): $(SRC)
-	$(CC) $(CPPFLAGS) $(LDFLAGS) $^ -o $@
-# C++ (GNU++20 (GCC 12.3.0))
+	@rm -f $(JUDGEDIR)/Main.cpp $(JUDGEDIR)/a.out
+	@cp $(SRC) $(JUDGEDIR)/Main.cpp
+	cd $(JUDGEDIR) && /judge/cpp.sh
+# C++ (GNU++23 (GCC 15.2.0))
 OJ_SFLAGS = -l 5001
 else
 ifeq ($(PROG),javascript)


### PR DESCRIPTION
## Summary

Implements smkwlab/atcoder-container#77: C++ compilation now uses `/judge` directory pattern, following the same approach as Java (#73) and JavaScript (#75).

This PR works in conjunction with smkwlab/atcoder-container#51.

## Changes

- **Update `lib/.support/makefile`**: Use `/judge` directory for C++ compilation
  - Set `JUDGEDIR=/judge`, `TARGET=/judge/a.out`
  - Copy `Main.cpp` to `/judge` and compile there
  - Execute `/judge/cpp.sh` for compilation
  - Update language ID comment to 5001 (GNU++23)
  - Remove STRICT_MODE branching (handled by cpp.sh)
- **Update `CLAUDE.md`**: Document C++ `/judge` directory usage
  - Mark C++ as using `/judge` directory pattern
  - Add note explaining clean problem directory benefit

## Benefits

- **Clean problem directories**: No `a.out` files generated in problem directories
- **Exact judge environment match**: Uses same compilation process as AtCoder judge
- **Consistent workflow**: Same pattern as Java (`am t .java`) and JavaScript (`am t .js`)

## Testing

✅ Tested with `am t .cpp` on `abc428/a`
- All 3 test cases passed (AC)
- Execution time: 0.003-0.004 seconds
- Memory usage: 3.072 MB
- No `a.out` files left in problem directory

## Related Issues

- Implements: smkwlab/atcoder-container#77
- Depends on: smkwlab/atcoder-container#51
- Related: #73 (Java /judge pattern), #75 (JavaScript /judge pattern)