### PR TITLE
Remove obsolete STRICT_MODE references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,17 +110,11 @@ docker ps --filter "name=atcoder-env" --format "table {{.ID}}\t{{.Names}}\t{{.St
 **重要**: makefileはasdfの環境が必要なため、`bash -i`（対話的シェル）で実行すること。
 
 ```bash
-# Java簡易モード
+# Java
 docker exec -i atcoder-env_devcontainer-dev-1 bash -i -c "cd /root/contest/abc123/a && make t PROG=java"
 
-# Java厳密モード（wrapper script使用）
-docker exec -i atcoder-env_devcontainer-dev-1 bash -i -c "cd /root/contest/abc123/a && STRICT_MODE=1 make t PROG=java"
-
-# JavaScript簡易モード
+# JavaScript
 docker exec -i atcoder-env_devcontainer-dev-1 bash -i -c "cd /root/contest/abc123/a && make t PROG=javascript"
-
-# JavaScript厳密モード（wrapper script使用）
-docker exec -i atcoder-env_devcontainer-dev-1 bash -i -c "cd /root/contest/abc123/a && STRICT_MODE=1 make t PROG=javascript"
 
 # Python
 docker exec -i atcoder-env_devcontainer-dev-1 bash -i -c "cd /root/contest/abc123/a && make t PROG=python"

--- a/bin/am
+++ b/bin/am
@@ -12,9 +12,7 @@ Usage: am <command> <params>
 command:
   new <contest_id>   create task directory
   t <extension>      test code by oj
-  ts <extension>     test code by oj (strict mode - same as judge environment)
   tf <extension>     test code by oj (with float tolerance)
-  tsf <extension>    test code by oj (strict mode with float tolerance)
   test <extension>   execute code and display results
   s <extension>      submit code by oj
   dl                 download test cases
@@ -24,42 +22,6 @@ EOF
 new|setup)
   CONTEST="$2"
   (cd ${CONTEST_DIR}; acc new ${CONTEST} --no-tests)
-  ;;
-ts|tsf)
-  export STRICT_MODE=1
-  if [ "${CMD}" = "ts" ]; then
-    CMD=t
-  else
-    CMD=tf
-  fi
-  EXT="$2"
-
-  case ${EXT} in
-  \.java)
-    PROG=java
-    ;;
-  \.py)
-    PROG=python
-    ;;
-  \.cpp|\.c++)
-    PROG=c++
-    ;;
-  \.rb)
-    PROG=ruby
-    ;;
-  \.ex)
-    PROG=elixir
-    ;;
-  \.rs)
-    PROG=rust
-    ;;
-  *)
-    PROG=UNKNOWN
-    ;;
-  esac
-
-  export PROG
-  make ${CMD}
   ;;
 *)
   EXT="$2"

--- a/lib/.support/makefile
+++ b/lib/.support/makefile
@@ -44,7 +44,7 @@ ELIXIRTARGET = Elixir.Main.beam
 
 RUBY = ruby
 
-PYTHON = python
+PYTHON = python3
 
 CC = g++
 CFLAGS = -std=gnu++20


### PR DESCRIPTION
## Summary

Implements #79: With the implementation of `/judge` directory pattern for all languages (Java #73, JavaScript #75, C++ #77), STRICT_MODE is no longer needed. All languages now always use judge environment settings by default.

## Changes

- **Remove STRICT_MODE documentation from `CLAUDE.md`**
  - Simplify test command examples (remove "strict mode" / "normal mode" variants)
  - Users no longer need to know about STRICT_MODE

- **Remove STRICT_MODE from `bin/am`**
  - Delete `ts`/`tsf` commands (now redundant with `t`/`tf`)
  - Remove `STRICT_MODE` export from code
  - Cleaner command interface

- **Fix makefile Python command**
  - Change `PYTHON` from `python` to `python3`
  - Fixes `python: No such file or directory` error
  - Matches actual Python installation in container

## Benefits

- **Simplified workflow**: No need to remember STRICT_MODE environment variable
- **Consistent behavior**: All languages always use judge environment settings
- **Reduced user confusion**: One less concept to understand
- **Cleaner codebase**: Remove obsolete functionality
- **Python tests work**: Fixed Python command reference

## Testing

✅ Tested in Dev Container:
- `am t .cpp`: 3/3 AC
- `am tf .cpp`: 3/3 AC (with float tolerance)
- `am t .py`: 3/3 AC (now works with python3 fix)

## Migration Notes

No user action required:
- `am t` and `am tf` commands continue to work as before
- `am ts` and `am tsf` commands removed (were redundant)
- Judge environment settings now always active by default

## Related Issues

- Closes #79
- Related: #73 (Java /judge pattern), #75 (JavaScript /judge pattern), #77, #78 (C++ /judge pattern)