### PR TITLE
Remove redundant jq installation from .devcontainer/Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,11 +2,6 @@ FROM ghcr.io/smkwlab/atcoder-container:202510update-lite
 
 ARG HOME=/root
 
-# Install additional tools not included in lite version
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    jq \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN echo ". ${HOME}/lib/.support/bash_functions.sh" >> ${HOME}/.bashrc
 ENV CONTEST_DIR /root/contest
 ENV PATH="/root/bin:${PATH}"


### PR DESCRIPTION
## Summary

Removes the redundant `jq` installation from `.devcontainer/Dockerfile` as `jq` is now included in the base image.

Resolves #85

## Investigation Findings

### Timeline

1. **2025-10-27 15:00**: `jq` installation added to `.devcontainer/Dockerfile`
2. **2025-10-27 19:43**: `jq` added to atcoder-container base images in commit [c54140f](https://github.com/smkwlab/atcoder-container/commit/c54140f)

### Verification

- ✅ `jq` is included in `atcoder-container:202510update-lite` (base image)
- ✅ `jq` is included in `atcoder-container:202510update-full` (base image)
- ✅ Both Dockerfile and Dockerfile.lite contain `jq` in their package lists
- ✅ Verified `jq` version 1.7 is available in running Dev Container

## Changes

### Before
```dockerfile
FROM ghcr.io/smkwlab/atcoder-container:202510update-lite

ARG HOME=/root

# Install additional tools not included in lite version
RUN apt-get update && apt-get install -y --no-install-recommends \
    jq \
    && rm -rf /var/lib/apt/lists/*

RUN echo ". ${HOME}/lib/.support/bash_functions.sh" >> ${HOME}/.bashrc
ENV CONTEST_DIR /root/contest
ENV PATH="/root/bin:${PATH}"
```

### After
```dockerfile
FROM ghcr.io/smkwlab/atcoder-container:202510update-lite

ARG HOME=/root

RUN echo ". ${HOME}/lib/.support/bash_functions.sh" >> ${HOME}/.bashrc
ENV CONTEST_DIR /root/contest
ENV PATH="/root/bin:${PATH}"
```

## Benefits

1. **Simpler Dockerfile**: Removed unnecessary RUN layer
2. **Faster builds**: No `apt-get update` and `apt-get install` needed
3. **Consistency**: Relies on base image capabilities
4. **Maintenance**: One less dependency to manage in atcoder-env

## jq Usage

`jq` is critical for makefile task URL parsing:

**lib/.support/makefile (line 150):**
```makefile
TASK_URL:=$$(cat ../contest.acc.json|jq -r ".tasks|map(select(.directory.path==\"$(TASK)\"))[]|.url")
```

Used by:
- `oj dl` - Downloading test cases
- `make open/web` - Opening task pages

This functionality remains intact as `jq` is provided by the base image.

## Risk Assessment

**Low Risk**: 
- Base image already provides `jq`
- No functional changes to container behavior
- Simplifies rather than complicates the setup