### PR TITLE
Fix Docker image cache issue by using direct image reference

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,0 @@
-FROM ghcr.io/smkwlab/atcoder-container:202510update-lite
-
-ARG HOME=/root
-
-RUN echo ". ${HOME}/lib/.support/bash_functions.sh" >> ${HOME}/.bashrc
-ENV CONTEST_DIR /root/contest
-ENV PATH="/root/bin:${PATH}"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,9 +1,7 @@
 version: '3'
 services:
   dev:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/smkwlab/atcoder-container:202510update-lite
 
     # localとcontainer間のファイルを同期させる
     # ${local}:${container}

--- a/bin/.postCreateContainer.sh
+++ b/bin/.postCreateContainer.sh
@@ -1,5 +1,16 @@
 #! /bin/bash
 
+echo 'setup environment variables in .bashrc'
+if ! grep -q 'bash_functions.sh' ${HOME}/.bashrc; then
+  echo '. ${HOME}/lib/.support/bash_functions.sh' >> ${HOME}/.bashrc
+fi
+if ! grep -q 'CONTEST_DIR' ${HOME}/.bashrc; then
+  echo 'export CONTEST_DIR=/root/contest' >> ${HOME}/.bashrc
+fi
+if ! grep -q '/root/bin' ${HOME}/.bashrc; then
+  echo 'export PATH="/root/bin:${PATH}"' >> ${HOME}/.bashrc
+fi
+
 echo 'create symlinks for makefile'
 cd ${HOME}/.config/atcoder-cli-nodejs
 progs=$(find . ! -name . -type d -print | sed -e 's,\./,,')


### PR DESCRIPTION
## Summary

古いキャッシュを持つPCで atcoder-env をcloneした際に、VS Code Dev Container が古いベースイメージから作られたキャッシュを再利用してしまい、Dockerfile の FROM で指定した最新イメージが使われない問題を修正しました。

## Problem

- 古い \`latest\` イメージでビルドされたキャッシュを持つPCでは、新しい \`202510update-lite\` ベースイメージが使われない
- docker-compose.yml が \`build\` を使用していたため、既存のビルドキャッシュが優先された
- Dockerfile の FROM が無視される状況が発生

## Solution

- docker-compose.yml を \`build\` から \`image\` に変更し、イメージを直接指定
- Dockerfile で設定していた環境変数を \`.postCreateContainer.sh\` に移行
- 不要になった \`.devcontainer/Dockerfile\` を削除

## Benefits

- 常に指定したイメージ（\`202510update-lite\`）が使用される
- ビルドキャッシュの問題が解消
- buildステップがないため起動が高速化
- 環境変数設定は重複チェック付きで \`.bashrc\` に追加される

## Changes

1. \`.devcontainer/docker-compose.yml\`: \`image: ghcr.io/smkwlab/atcoder-container:202510update-lite\` に変更
2. \`bin/.postCreateContainer.sh\`: 環境変数設定を追加（bash_functions.sh, CONTEST_DIR, PATH）
3. \`.devcontainer/Dockerfile\`: 削除

## Test plan

- [ ] 古いキャッシュを持つPCで \`git pull\` して VS Code で開く
- [ ] 正しいイメージ（\`202510update-lite\`）が使われることを確認
- [ ] \`echo $CONTEST_DIR\` で環境変数が設定されていることを確認
- [ ] \`which am\` で PATH が正しく設定されていることを確認
- [ ] \`am new\` でコンテストセットアップが正常に動作することを確認