### PR TITLE
Add remoteEnv to devcontainer.json for VS Code tasks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,12 @@
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
 	"workspaceFolder": "/root",
 
+	// Environment variables for VS Code and tasks
+	"remoteEnv": {
+		"PATH": "/root/bin:${containerEnv:PATH}",
+		"CONTEST_DIR": "/root/contest"
+	},
+
 	// Customizations for VS Code
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
## Summary

PR #88 で環境変数設定を \`.bashrc\` に移したことで、VS Code の Task から AtCoder コマンド（\`am\` など）が見つからない問題を修正しました。

## Problem

- PR #88 で \`PATH\` と \`CONTEST_DIR\` を \`.bashrc\` に設定
- ターミナルでは正常に動作するが、VS Code の Task は \`.bashrc\` を読み込まない
- そのため Task から \`am\` コマンドを実行すると "command not found" エラー

## Solution

devcontainer.json に \`remoteEnv\` セクションを追加：
\`\`\`json
"remoteEnv": {
  "PATH": "/root/bin:${containerEnv:PATH}",
  "CONTEST_DIR": "/root/contest"
}
\`\`\`

## Benefits

- VS Code の Task、デバッガー、拡張機能すべてで環境変数が利用可能
- AtCoder コマンドが Task から正常に実行できる
- ターミナルとタスクの両方で一貫した環境

## Changes

- \`.devcontainer/devcontainer.json\`: \`remoteEnv\` セクションを追加

## Test plan

- [ ] コンテナを再ビルド（Rebuild Container）
- [ ] Task から "AtCoder: TEST code" を実行して \`am\` が認識されることを確認
- [ ] Task から "AtCoder: SUBMIT code" を実行して正常に動作することを確認
- [ ] ターミナルで \`echo $PATH\` と \`echo $CONTEST_DIR\` が正しく表示されることを確認