### PR TITLE
Fix Java home variable error in VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,10 @@
 				"terminal.integrated.fontSize": 14,
 				"terminal.integrated.fontFamily": "HackGen, 'BIZ UDPGothic', Meiryo, 'Hiragino Kaku Gothic ProN', 'SF Mono', Consolas, monospace",
 				//"workbench.colorTheme": "Default Light+",
-				"window.zoomLevel": 0
+				"window.zoomLevel": 0,
+				// Java settings - override host settings for container
+				"java.jdt.ls.java.home": null,
+				"java.configuration.runtimes": []
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [


### PR DESCRIPTION
## Summary

VS Code の Java 拡張機能が「java.jdt.ls.java.home がホストマシンの存在しないフォルダ (c:\Java\jdk-17) を参照している」というエラーを表示する問題を修正しました。

## Problem

VS Code で以下のエラーが表示される：
```
The java.jdt.ls.java.home variable defined in Visual Studio 
Code settings points to a missing or inaccessible folder 
(c:\Java\jdk-17)
```

これは、ホストマシンのJava設定がコンテナ環境でも適用されていたためです。

## Solution

devcontainer.json に Java 固有の設定を追加し、ホスト設定を上書き：
\`\`\`json
"java.jdt.ls.java.home": null,
"java.configuration.runtimes": []
\`\`\`

これにより、VS Code の Java 拡張機能がコンテナ内の Java インストール (\`/usr/local/bin/java\`) を自動検出して使用します。

## Changes

- \`.devcontainer/devcontainer.json\`: Java 設定を追加してホスト設定を無効化

## Test plan

- [ ] コンテナを再起動（Reload Window）
- [ ] Java ファイルを開いてエラーが表示されないことを確認
- [ ] Java Language Server が正常に起動することを確認
- [ ] Java コードの補完・エラーチェックが動作することを確認