### PR TITLE
Remove strict mode tasks from VS Code tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -66,46 +66,6 @@
               }
         },
         {
-            "label": "AtCoder: TEST(strict) code",
-            "type": "shell",
-            "options": {
-                "cwd": "${fileDirname}"
-            },
-            "command": "am ts ${fileExtname}",
-            "problemMatcher": [],
-            "presentation": {
-                "echo": false,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "group": {
-                "kind": "test"
-            }
-        },
-        {
-            "label": "AtCoder: TEST(strict,float) code",
-            "type": "shell",
-            "options": {
-                "cwd": "${fileDirname}"
-            },
-            "command": "am tsf ${fileExtname}",
-            "problemMatcher": [],
-            "presentation": {
-                "echo": false,
-                "reveal": "always",
-                "focus": false,
-                "panel": "shared",
-                "showReuseMessage": false,
-                "clear": true
-            },
-            "group": {
-                "kind": "test"
-            }
-        },
-        {
             "label": "AtCoder: SUBMIT code",
             "type": "shell",
             "options": {


### PR DESCRIPTION
## Summary

\`.vscode/tasks.json\` から strict mode 関連の2つのタスクを削除しました。

## Changes

削除したタスク：
- **AtCoder: TEST(strict) code** (\`am ts\`)
- **AtCoder: TEST(strict,float) code** (\`am tsf\`)

## Reason

strict mode は廃止されたため、対応するタスクも不要になりました。

## Remaining Tasks

以下のタスクは引き続き使用可能：
- AtCoder: OPEN Task Page
- AtCoder: TEST code
- AtCoder: TEST(float) code  
- AtCoder: SUBMIT code
- AtCoder: setup NEW contest

Resolves #91