### PR TITLE
Add aclogin support for AtCoder login (Issue #93)

### DIFF
--- a/bin/.postCreateContainer.sh
+++ b/bin/.postCreateContainer.sh
@@ -25,30 +25,46 @@ echo '=========================================='
 echo
 
 # Check if already logged in
-if acc session >/dev/null 2>&1; then
-    echo 'AtCoder に既にログイン済みです。'
+# Note: Authentication is persisted in ~/.config/atcoder-cli-nodejs/ and ~/.local/share/online-judge-tools/
+SESSION_CHECK=$(acc session 2>&1)
+if echo "$SESSION_CHECK" | grep -q "logged in\|ログイン済み"; then
+    echo '✓ AtCoder に既にログイン済みです。'
+    echo
+elif echo "$SESSION_CHECK" | grep -q "network\|timeout\|接続\|failed to connect"; then
+    echo '⚠ 警告: ネットワークエラーによりログイン状態を確認できません。'
+    echo '後で手動で確認してください: acc session'
     echo
 else
-    echo '【重要】AtCoder ログインについて'
+    echo '【注意】AtCoder ログインが必要です'
     echo
-    echo 'AtCoder の仕様変更により、acc と oj の自動ログインが'
-    echo 'できなくなっています。代わりに aclogin でログインしてください。'
-    echo
-    echo '■ Cookie の取得方法:'
-    echo '  1. ブラウザで https://atcoder.jp にログイン'
-    echo '  2. 開発者ツール（F12）を開く'
-    echo '  3. Application（Chrome）または Storage（Firefox）タブを選択'
-    echo '  4. Cookies から REVEL_SESSION の値をコピー'
-    echo
-    echo '詳細: https://qiita.com/namonaki/items/16cda635dd7c34496aaa'
-    echo
-    echo '以下でクッキーを入力してください（スキップする場合は Ctrl+C）:'
+    echo 'AtCoder の仕様変更により手動ログインが必要です。'
     echo
 
-    if command -v aclogin >/dev/null 2>&1; then
-        aclogin || echo 'aclogin をスキップしました。後で手動で実行できます: aclogin'
+    # Check if running in interactive terminal (TTY available)
+    if [ -t 0 ] && [ -t 1 ]; then
+        # Interactive environment - prompt for login
+        echo 'Cookie の取得方法:'
+        echo '  1. ブラウザで https://atcoder.jp にログイン'
+        echo '  2. 開発者ツール（F12）→ Application → Cookies'
+        echo '  3. REVEL_SESSION の値をコピー'
+        echo
+        echo '詳細: https://qiita.com/namonaki/items/16cda635dd7c34496aaa'
+        echo
+        echo 'クッキーを入力してください（Ctrl+C でスキップ）:'
+        echo
+
+        if command -v aclogin >/dev/null 2>&1; then
+            aclogin || true
+        else
+            echo 'エラー: aclogin コマンドが見つかりません。'
+            echo '最新のコンテナイメージを使用してください。'
+        fi
     else
-        echo 'エラー: aclogin コマンドが見つかりません。'
-        echo '最新のコンテナイメージを使用してください。'
+        # Non-interactive environment (Codespaces, CI, etc.)
+        echo 'コンテナ作成後、ターミナルで以下を実行してください:'
+        echo '  aclogin'
+        echo
+        echo 'Cookie 取得方法: https://qiita.com/namonaki/items/16cda635dd7c34496aaa'
     fi
+    echo
 fi


### PR DESCRIPTION
## Summary

This PR adds support for the \`aclogin\` tool to address AtCoder's login specification changes that prevent automated login through \`acc\` and \`oj\`.

Addresses Issue #93

## Changes

- **Removed automatic login**: Removed \`acc login\` and \`oj login\` commands from \`.postCreateContainer.sh\`
- **Added aclogin usage guide**: Added detailed instructions for Cookie acquisition
- **Execute aclogin interactively**: Run \`aclogin\` at the end of setup to allow users to directly input Cookie

## User Experience

When the container is created, users will see:
1. Instructions for obtaining REVEL_SESSION cookie from browser
2. Reference link to detailed guide
3. aclogin prompt waiting for Cookie input

This eliminates the need for users to manually run aclogin after setup.

## Dependencies

Requires atcoder-container with aclogin installed (PR #64, already merged)

## Test plan

- [ ] Verify container setup completes without errors
- [ ] Confirm aclogin guide message is displayed
- [ ] Test aclogin prompts for Cookie input
- [ ] Verify authentication succeeds with valid Cookie
