### PR TITLE
Add pull_policy: always to ensure latest image is used

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   dev:
     image: ghcr.io/smkwlab/atcoder-container:202510update-lite
+    pull_policy: always
 
     # localとcontainer間のファイルを同期させる
     # ${local}:${container}


### PR DESCRIPTION
## Summary

Fixes #97

docker-compose.yml に `pull_policy: always` を追加して、常に最新の Docker イメージを使用するようにしました。

## Problem

新しくリポジトリを clone したユーザーが古い Docker イメージを使用してしまい、jq コマンドが見つからないなどの問題が発生していました。

## Solution

```yaml
services:
  dev:
    image: ghcr.io/smkwlab/atcoder-container:202510update-lite
    pull_policy: always  # ← 追加
```

`pull_policy: always` を設定することで、コンテナ起動時に常に最新のイメージを確認し、更新があれば自動的にダウンロードします。

## Benefits

1. **自動更新**: ユーザーが手動で `docker pull` する必要がない
2. **常に最新**: イメージ更新時に自動的に最新版を取得
3. **問題回避**: 古いイメージによる互換性問題を防止

## Impact

- コンテナ起動時にネットワークチェックが発生（わずかな遅延）
- 既に最新の場合は、チェックのみで実際のダウンロードは発生しない

## Testing

- docker-compose.yml の構文が正しいことを確認
- `pull_policy: always` は Docker Compose v3 でサポートされている標準オプション