### PR TITLE
Preserve postCreateContainer output and add login reminder

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -92,7 +92,7 @@
 	// "shutdownAction": "none",
 
 	// Run commands after the container is created.
-	"postCreateCommand": "bin/.postCreateContainer.sh"
+	"postCreateCommand": "bin/.postCreateContainer.sh 2>&1 | tee /tmp/postCreateContainer.log"
 
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"

--- a/bin/.postCreateContainer.sh
+++ b/bin/.postCreateContainer.sh
@@ -68,3 +68,23 @@ else
     fi
     echo
 fi
+
+# Add login reminder to .bashrc
+echo 'add login reminder to .bashrc'
+if ! grep -q 'ATCODER_LOGIN_CHECKED' ${HOME}/.bashrc; then
+    cat >> ${HOME}/.bashrc << 'EOF'
+
+# Check AtCoder login status (once per shell session)
+if [ -z "$ATCODER_LOGIN_CHECKED" ]; then
+    export ATCODER_LOGIN_CHECKED=1
+
+    if ! acc session 2>&1 | grep -q "logged in\|ログイン済み"; then
+        echo ""
+        echo "⚠️  AtCoder ログインが必要です"
+        echo "    ログイン方法: aclogin"
+        echo "    詳細: https://qiita.com/namonaki/items/16cda635dd7c34496aaa"
+        echo ""
+    fi
+fi
+EOF
+fi


### PR DESCRIPTION
## Summary

Fixes #99

コンテナビルド時のターミナルを閉じてもセットアップ情報を確認できるようにし、ログインが必要な場合は新しいターミナルで通知するようにしました。

## Problem

コンテナビルド時のターミナルを不用意に閉じてしまい、`.postCreateContainer.sh` の出力（特に AtCoder ログインに関するメッセージ）を見逃してしまうケースがあった。

## Solution

### 1. ログファイルへの出力保存

`devcontainer.json` の `postCreateCommand` で `tee` を使用して出力を保存：

```json
"postCreateCommand": "bin/.postCreateContainer.sh 2>&1 | tee /tmp/postCreateContainer.log"
```

ユーザーは後から以下で確認可能：
```bash
cat /tmp/postCreateContainer.log
```

### 2. .bashrc でのログイン状態チェック

`.postCreateContainer.sh` で `.bashrc` にログイン状態チェックを追加：

```bash
# Check AtCoder login status (once per shell session)
if [ -z "$ATCODER_LOGIN_CHECKED" ]; then
    export ATCODER_LOGIN_CHECKED=1

    if ! acc session 2>&1 | grep -q "logged in\|ログイン済み"; then
        echo ""
        echo "⚠️  AtCoder ログインが必要です"
        echo "    ログイン方法: aclogin"
        echo "    詳細: https://qiita.com/namonaki/items/16cda635dd7c34496aaa"
        echo ""
    fi
fi
```

## Benefits

1. **情報保持**: ターミナルを閉じても `/tmp/postCreateContainer.log` から確認可能
2. **自動通知**: 新しいターミナルを開くたびにログイン状態をチェック
3. **非侵入的**: ログイン済みの場合は通知されない
4. **セッション内1回のみ**: 環境変数 `ATCODER_LOGIN_CHECKED` により同じシェルセッション内で繰り返し表示されない

## Testing

- devcontainer.json の JSON 構文が正しいことを確認
- .bashrc への追加処理が重複しないことを確認（grep チェック）
- ログイン済み/未ログインの両方のケースで動作確認