### PR TITLE
Fix stale compiled files issue when switching between problems

### DIFF
--- a/lib/.support/makefile
+++ b/lib/.support/makefile
@@ -41,6 +41,7 @@ ifeq ($(PROG),java)
 SRC = Main.java
 TARGET = $(JUDGEDIR)/Main.class
 RUN_TEST = sh /judge/java.sh 1024 $(JUDGEDIR)
+.PHONY: $(TARGET)
 $(TARGET): $(SRC)
 	@rm -f $(JUDGEDIR)/$(SRC) $(TARGET)
 	cp $(SRC) $(JUDGEDIR)/$(SRC)
@@ -53,6 +54,7 @@ SRC = Main.ex
 ELIXIR_WORKDIR = $(JUDGEDIR)/main
 TARGET = $(ELIXIR_WORKDIR)/_build/prod/rel/main/bin/main
 RUN_TEST = $(TARGET) eval Main.main
+.PHONY: $(TARGET)
 $(TARGET): $(SRC)
 	@rm -f $(ELIXIR_WORKDIR)/lib/$(SRC) $(TARGET)
 	cp $(SRC) $(ELIXIR_WORKDIR)/lib/$(SRC)
@@ -82,6 +84,7 @@ ifeq ($(PROG), c++)
 SRC = Main.cpp
 TARGET = $(JUDGEDIR)/a.out
 RUN_TEST = $(JUDGEDIR)/a.out
+.PHONY: $(TARGET)
 $(TARGET): $(SRC)
 	@rm -f $(JUDGEDIR)/$(SRC) $(TARGET)
 	cp $(SRC) $(JUDGEDIR)/$(SRC)
@@ -100,6 +103,7 @@ ifeq ($(PROG),erlang)
 SRC = Main.erl
 TARGET = $(JUDGEDIR)/Main.beam
 RUN_TEST = sh -c "cd $(JUDGEDIR) && erl -noshell -run Main main run"
+.PHONY: $(TARGET)
 $(TARGET): $(SRC)
 	@rm -f $(JUDGEDIR)/$(SRC) $(TARGET)
 	cp $(SRC) $(JUDGEDIR)/$(SRC)
@@ -120,6 +124,7 @@ ifeq ($(PROG), rust)
 SRC = main.rs
 TARGET = $(JUDGEDIR)/target/release/main
 RUN_TEST = $(JUDGEDIR)/target/release/main
+.PHONY: $(TARGET)
 $(TARGET): $(SRC)
 	@rm -f $(JUDGEDIR)/src/$(SRC) $(TARGET)
 	cp $(SRC) $(JUDGEDIR)/src/$(SRC)


### PR DESCRIPTION
## 問題

異なる問題間を移動した際に、古いコンパイル済みファイルでテストが実行されてしまう深刻なバグを修正します。

### 再現シナリオ

1. `abc428/a/Main.java` を編集してテスト実行
2. VS Code で `abc429/a/Main.java` を開く
3. テストを実行
4. **結果**: abc428 の古いクラスファイルで abc429 のテストが実行される ❌

これは **間違ったコードでテストが通ってしまう** 可能性があり、非常に危険です。

## 根本原因

makefile の依存関係チェック：

```makefile
$(TARGET): $(SRC)
	@rm -f $(JUDGEDIR)/$(SRC) $(TARGET)
	cp $(SRC) $(JUDGEDIR)/$(SRC)
	javac ...
```

- `/judge/Main.class` が存在し、`Main.java` より新しい
- → make がルールをスキップ（再コンパイルしない）
- → 別の問題の古いクラスファイルが使われる

## 解決策

`.PHONY` ターゲットを追加して、タイムスタンプに関係なく常にリビルドする：

```makefile
.PHONY: $(TARGET)
$(TARGET): $(SRC)
	@rm -f $(JUDGEDIR)/$(SRC) $(TARGET)
	cp $(SRC) $(JUDGEDIR)/$(SRC)
	javac ...
```

## 修正対象

コンパイルが必要な全言語に適用：

- ✅ **Java** - `/judge/Main.class`
- ✅ **C++** - `/judge/a.out`
- ✅ **Erlang** - `/judge/Main.beam`
- ✅ **Elixir** - Mix release
- ✅ **Rust** - cargo binary

インタプリタ言語（Python、Ruby、JavaScript、PHP）は影響なし。

## メリット

1. ✅ **正確性**: 常に最新のソースがコンパイルされる
2. ✅ **安全性**: 間違ったコードでテストが通ることがない
3. ✅ **シンプル**: 実装が明確で理解しやすい

## デメリットとトレードオフ

⚠️ ソースを変更していなくても毎回コンパイルされる（わずかな時間のオーバーヘッド）

**ただし**:
- 競プロでは通常、ソースを変更してからテストする
- コンパイル時間は数秒程度
- 間違ったコードでテストが通るリスクと比較すると、このオーバーヘッドは許容範囲

## テスト方法

### Java の例

1. `abc428/a/Main.java` に以下を追加:
\`\`\`java
System.out.println("428");
\`\`\`

2. `am t .java` を実行 → "428" が出力される

3. `abc429/a/Main.java` に以下を追加:
\`\`\`java
System.out.println("429");
\`\`\`

4. `am t .java` を実行 → **"429" が出力される** ✅

**修正前**: "428" が出力される（バグ）

### 他の言語でも同様にテスト可能

Resolves #109