### PR TITLE
Set default CONTEST_DIR in am script

### DIFF
--- a/bin/am
+++ b/bin/am
@@ -2,6 +2,9 @@
 # AtCoder frontend utility for (formaly) Make
 #set -x
 
+# Set default CONTEST_DIR if not set
+: ${CONTEST_DIR:=$HOME/contest}
+
 CMD="$1"
 
 case ${CMD} in


### PR DESCRIPTION
## 問題

`am new <contest_id>`を実行すると、コンテストディレクトリが`/root/contest`ではなく、カレントディレクトリ（例: `/root`）に作成されてしまう問題がありました。

**再現手順**:
```bash
# /root で実行
am new abc430
# 結果: /root/abc430 が作成される（期待: /root/contest/abc430）
```

## 原因

`am`スクリプト（line 24）で`${CONTEST_DIR}`を使用していますが、devcontainer.jsonの`remoteEnv`設定はVS Codeのリモートセッションにのみ適用され、すべてのシェルセッションには適用されません。

```bash
# devcontainer.jsonの設定はVS Code経由のみ有効
"remoteEnv": {
    "CONTEST_DIR": "/root/contest"
}
```

直接シェルセッションから`am`を実行すると、`CONTEST_DIR`が未設定のため、`cd`が空文字列となり、カレントディレクトリで`acc new`が実行されます。

## 修正内容

`am`スクリプトにデフォルト値を設定：

```bash
# Set default CONTEST_DIR if not set
: ${CONTEST_DIR:=$HOME/contest}
```

### 設計の選択

- **`$HOME/contest`を使用**: `/root`をハードコードせず、将来的に非rootユーザーでも動作
- **devcontainer.jsonの設定は維持**: VS Code環境との一貫性を保持
- **冗長性による堅牢性**: 両方で設定することで、どちらの環境でも確実に動作

## 影響範囲

- `am new`コマンドが常に`$HOME/contest`（通常は`/root/contest`）にディレクトリを作成
- VS Code環境: 変更なし（devcontainer.jsonの設定が優先）
- 直接シェル: 正しく動作するようになる

## テスト

```bash
# CONTEST_DIRが未設定の場合
docker exec atcoder-env_devcontainer-dev-1 bash -c 'source /root/bin/am; echo "CONTEST_DIR: ${CONTEST_DIR}"'
# 出力: CONTEST_DIR: /root/contest
```