### PR TITLE
Auto-open contest directory after setup

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -88,7 +88,7 @@
             "options": {
                 "cwd": "${env:CONTEST_DIR}"
             },
-            "command": "am new ${input:contest_id}; echo;echo VSCodeのエクスプローラーで contest/${input:contest_id} フォルダを開いてください。;echo",
+            "command": "am new ${input:contest_id} && am open-first ${input:contest_id}",
             "presentation": {
                 "echo": false,
                 "reveal": "always",

--- a/README.md
+++ b/README.md
@@ -270,7 +270,44 @@ Dev Container 外なら atcoder-cli-nodejs/ に設定ファイルが存在。
 各言語用テンプレートファイルはこのディレクトリ下の言語名ディレクトリ下にあるので、
 好みに編集するのが推奨。
 
-### 6.2 コード提出時言語選択
+### 6.2 デフォルト言語の設定
+
+「AtCoder: setup NEW contest」タスクでコンテストをセットアップした後、自動的に開くファイルの言語を設定できる。
+
+コンテナ初期化時に `~/.atcoder-default-lang` ファイルが作成され、デフォルトは `java` に設定される。
+
+#### 6.2.1 設定の変更
+
+```bash
+# Python をデフォルトに変更
+echo 'python' > ~/.atcoder-default-lang
+
+# C++ をデフォルトに変更
+echo 'cpp' > ~/.atcoder-default-lang
+
+# 現在の設定を確認
+cat ~/.atcoder-default-lang
+```
+
+#### 6.2.2 対応言語
+
+| 言語 | 設定値 | 開かれるファイル |
+|------|--------|------------------|
+| Java | `java` | `Main.java` |
+| Python | `python` または `py` | `Main.py` |
+| C++ | `cpp` または `c++` | `Main.cpp` |
+| Ruby | `ruby` または `rb` | `Main.rb` |
+| Elixir | `elixir` または `ex` | `Main.ex` |
+| Erlang | `erlang` または `erl` | `Main.erl` |
+| JavaScript | `javascript` または `js` | `Main.js` |
+| PHP | `php` | `Main.php` |
+| Rust | `rust` または `rs` | `main.rs` |
+
+#### 6.2.3 高度な設定
+
+環境変数 `ATCODER_DEFAULT_LANG` を設定することもできるが、`~/.atcoder-default-lang` ファイルが優先される。
+
+### 6.3 コード提出時言語選択
 
 プログラミング言語はファイルの拡張子で決定。
 `bin/am` スクリプト内で判定。

--- a/bin/.postCreateContainer.sh
+++ b/bin/.postCreateContainer.sh
@@ -122,3 +122,13 @@ if [ -f ~/.atcoder_login_check.sh ]; then
 fi
 EOF
 fi
+
+# Create default language configuration file
+echo 'setup default language configuration'
+if [ ! -f ~/.atcoder-default-lang ]; then
+    echo 'java' > ~/.atcoder-default-lang
+    echo '✓ デフォルト言語を java に設定しました'
+    echo '  変更方法: echo "python" > ~/.atcoder-default-lang'
+    echo '  対応言語: java, python, cpp, ruby, elixir, erlang, javascript, php, rust'
+    echo
+fi

--- a/bin/am
+++ b/bin/am
@@ -14,6 +14,8 @@ Usage: am <command> <params>
 
 command:
   new <contest_id>   create task directory
+  open-first <contest_id>
+                     open first problem file in VS Code
   t <extension>      test code by oj
   tf <extension>     test code by oj (with float tolerance)
   test <extension>   execute code and display results
@@ -25,6 +27,58 @@ EOF
 new|setup)
   CONTEST="$2"
   (cd ${CONTEST_DIR}; acc new ${CONTEST} --no-tests)
+  ;;
+open-first)
+  CONTEST="$2"
+
+  # Get default language
+  # Priority: 1. ~/.atcoder-default-lang, 2. Environment variable, 3. Default (java)
+  if [ -f ~/.atcoder-default-lang ]; then
+    LANG=$(cat ~/.atcoder-default-lang | tr -d '[:space:]')
+  elif [ -n "${ATCODER_DEFAULT_LANG}" ]; then
+    LANG="${ATCODER_DEFAULT_LANG}"
+  else
+    LANG="java"
+  fi
+
+  # Map language to filename
+  case ${LANG} in
+  java)
+    FILE="Main.java"
+    ;;
+  python|py)
+    FILE="Main.py"
+    ;;
+  cpp|c++)
+    FILE="Main.cpp"
+    ;;
+  ruby|rb)
+    FILE="Main.rb"
+    ;;
+  elixir|ex)
+    FILE="Main.ex"
+    ;;
+  erlang|erl)
+    FILE="Main.erl"
+    ;;
+  javascript|js)
+    FILE="Main.js"
+    ;;
+  php)
+    FILE="Main.php"
+    ;;
+  rust|rs)
+    FILE="main.rs"
+    ;;
+  *)
+    echo "Unknown language: ${LANG}"
+    echo "Supported: java, python, cpp, ruby, elixir, erlang, javascript, php, rust"
+    exit 1
+    ;;
+  esac
+
+  # Open the file in VS Code (reuse window)
+  code -r "${CONTEST_DIR}/${CONTEST}/a/${FILE}"
   ;;
 *)
   EXT="$2"


### PR DESCRIPTION
## 概要

「AtCoder: setup NEW contest」タスクでコンテストをセットアップした後、自動的に指定した言語のファイルをVS Codeで開くようにしました。

## 主な機能

### 1. `am open-first` コマンドの追加

コンテストIDを指定すると、設定された言語のファイルを自動的に開くコマンド：

```bash
am open-first abc123  # ~/.atcoder-default-lang の設定に基づいてファイルを開く
```

### 2. デフォルト言語の設定

コンテナ初期化時に `~/.atcoder-default-lang` ファイルが作成され、デフォルトは `java` に設定されます。

変更方法：
```bash
# Python をデフォルトに変更
echo 'python' > ~/.atcoder-default-lang

# C++ をデフォルトに変更
echo 'cpp' > ~/.atcoder-default-lang

# 現在の設定を確認
cat ~/.atcoder-default-lang
```

### 3. 対応言語

| 言語 | 設定値 | 開かれるファイル |
|------|--------|------------------|
| Java | `java` | `Main.java` |
| Python | `python` または `py` | `Main.py` |
| C++ | `cpp` または `c++` | `Main.cpp` |
| Ruby | `ruby` または `rb` | `Main.rb` |
| Elixir | `elixir` または `ex` | `Main.ex` |
| Erlang | `erlang` または `erl` | `Main.erl` |
| JavaScript | `javascript` または `js` | `Main.js` |
| PHP | `php` | `Main.php` |
| Rust | `rust` または `rs` | `main.rs` |

## 変更内容

### bin/am
- `open-first` サブコマンドを追加
- 設定ファイル（`~/.atcoder-default-lang`）または環境変数（`ATCODER_DEFAULT_LANG`）から言語を読み取る
- 優先順位：設定ファイル > 環境変数 > デフォルト(java)

### bin/.postCreateContainer.sh
- コンテナ初期化時に `~/.atcoder-default-lang` ファイルを作成
- デフォルト値として `java` を設定

### .vscode/tasks.json
- `AtCoder: setup NEW contest` タスクを更新
- `am new ${input:contest_id} && am open-first ${input:contest_id}` を実行

### README.md
- セクション 6.2「デフォルト言語の設定」を追加
- 設定変更方法、対応言語、高度な設定を説明

## 効果

### ユーザー体験の改善
1. コンテストセットアップ後の手動操作が不要
2. 自分が使う言語のファイルが自動的に開く
3. ワークスペース構造（/root）が維持され、他の問題や言語も見える
4. 簡単に言語設定を変更できる

### ワークフロー
```
タスク実行 → コンテスト作成 → 設定した言語のファイルを開く → すぐにコーディング開始
```