### PR TITLE
Refactor Elixir template to use Process dictionary for input management

### DIFF
--- a/atcoder-cli-nodejs/all/Main.ex
+++ b/atcoder-cli-nodejs/all/Main.ex
@@ -26,6 +26,21 @@ defmodule Main do
   #
   # helper 関数群
   #
+  # Process辞書から入力を取得/更新 (初回アクセス時に自動初期化)
+  defp get_input do
+    case Process.get(:input) do
+      nil ->
+        lines =
+          "/dev/stdin"
+          |> File.read!()
+          |> String.split("\n", trim: true)
+        Process.put(:input, lines)
+        lines
+      lines ->
+        lines
+    end
+  end
+  defp update_input(new_input), do: Process.put(:input, new_input)
 
   # 文字列1行読み込み
   @spec read_string() :: String.t
@@ -34,9 +49,9 @@ defmodule Main do
   # out:
   # "rikka"
   def read_string do
-    :line
-    |> IO.read()
-    |> String.trim
+    [result | rest] = get_input()
+    update_input(rest)
+    result
   end
 
   # 整数1行読み込み
@@ -82,9 +97,9 @@ defmodule Main do
   # out:
   # ["rikka", "akane", "namiko"]
   def read_string_lines do
-    :eof
-    |> IO.read()
-    |> String.split("\n", trim: true)
+    input = get_input()
+    update_input([])
+    input
   end
 
   # 整数全行読み込み
@@ -137,12 +152,9 @@ defmodule Main do
   # out:
   # ["rikka", "akane", "namiko"]
   def read_string_lines(n) do
-    read_string_lines(n, [])
-  end
-
-  def read_string_lines(0, acc), do: Enum.reverse(acc)
-  def read_string_lines(n, acc) do
-    read_string_lines(n - 1, [read_string() | acc])
+    {result, rest} = Enum.split(get_input(), n)
+    update_input(rest)
+    result
   end
 
   # 行数指定整数複数行読み込み

--- a/atcoder-cli-nodejs/elixir/Main.ex
+++ b/atcoder-cli-nodejs/elixir/Main.ex
@@ -26,6 +26,21 @@ defmodule Main do
   #
   # helper 関数群
   #
+  # Process辞書から入力を取得/更新 (初回アクセス時に自動初期化)
+  defp get_input do
+    case Process.get(:input) do
+      nil ->
+        lines =
+          "/dev/stdin"
+          |> File.read!()
+          |> String.split("\n", trim: true)
+        Process.put(:input, lines)
+        lines
+      lines ->
+        lines
+    end
+  end
+  defp update_input(new_input), do: Process.put(:input, new_input)
 
   # 文字列1行読み込み
   @spec read_string() :: String.t
@@ -34,9 +49,9 @@ defmodule Main do
   # out:
   # "rikka"
   def read_string do
-    :line
-    |> IO.read()
-    |> String.trim
+    [result | rest] = get_input()
+    update_input(rest)
+    result
   end
 
   # 整数1行読み込み
@@ -82,9 +97,9 @@ defmodule Main do
   # out:
   # ["rikka", "akane", "namiko"]
   def read_string_lines do
-    :eof
-    |> IO.read()
-    |> String.split("\n", trim: true)
+    input = get_input()
+    update_input([])
+    input
   end
 
   # 整数全行読み込み
@@ -137,12 +152,9 @@ defmodule Main do
   # out:
   # ["rikka", "akane", "namiko"]
   def read_string_lines(n) do
-    read_string_lines(n, [])
-  end
-
-  def read_string_lines(0, acc), do: Enum.reverse(acc)
-  def read_string_lines(n, acc) do
-    read_string_lines(n - 1, [read_string() | acc])
+    {result, rest} = Enum.split(get_input(), n)
+    update_input(rest)
+    result
   end
 
   # 行数指定整数複数行読み込み


### PR DESCRIPTION
## Summary

Refactors the Elixir template (`Main.ex`) to use Process dictionary for input management instead of `IO.read()`.

## Changes

### New Helper Functions
- **`get_input/0`**: Retrieves input from Process dictionary (auto-initializes from `/dev/stdin` on first access)
- **`update_input/1`**: Updates remaining input in Process dictionary

### Refactored Functions
- **`read_string/0`**: Uses `get_input/0` instead of `IO.read(:line)`
- **`read_string_lines/0`**: Uses `get_input/0` instead of `IO.read(:eof)`
- **`read_string_lines/1`**: Simplified using `Enum.split/2` (eliminates recursive helper)

## Benefits

1. **Performance**: Reads stdin once instead of multiple `IO.read/1` calls
2. **Code Quality**: Cleaner implementation, removes recursive helper function
3. **Testability**: Can pre-populate Process dictionary in tests for easier testing

## Technical Details

The Process dictionary approach:
```elixir
# First access: reads /dev/stdin and stores in Process dictionary
input = get_input()  # ["line1", "line2", "line3"]

# Subsequent access: returns stored value
input = get_input()  # Same data from Process dictionary
```

## Testing Plan

- [ ] Test with single-line input
- [ ] Test with multi-line input
- [ ] Test with `read_string_lines/1` (n lines)
- [ ] Verify all helper functions work correctly