### PR TITLE
Refactor Elixir template: convert macros to functions to resolve definition order issues

### DIFF
--- a/atcoder-cli-nodejs/all/Main.ex
+++ b/atcoder-cli-nodejs/all/Main.ex
@@ -46,19 +46,21 @@ defmodule Main do
     quote do: Process.put(:input, unquote(new_input))
   end
 
-  # 文字列1行読み込み
-  # Returns: String.t
-  # in:
-  # rikka
-  # out:
-  # "rikka"
-  defmacro read_string do
+  defmacro pop_line do
     quote do
       [__result__ | __rest__] = get_input()
       Process.put(:input, __rest__)
       __result__
     end
   end
+
+  # 文字列1行読み込み
+  @spec read_string() :: String.t
+  # in:
+  # rikka
+  # out:
+  # "rikka"
+  def read_string, do: pop_line()
 
   # 整数1行読み込み
   @spec read_integer() :: integer
@@ -89,19 +91,17 @@ defmodule Main do
   end
 
   # 文字列全行読み込み
-  # Returns: [String.t]
+  @spec read_string_lines() :: [String.t]
   # in:
   # rikka
   # akane
   # namiko
   # out:
   # ["rikka", "akane", "namiko"]
-  defmacro read_string_lines do
-    quote do
-      __all_input__ = get_input()
-      update_input([])
-      __all_input__
-    end
+  def read_string_lines do
+    all_input = get_input()
+    update_input([])
+    all_input
   end
 
   # 整数全行読み込み
@@ -143,20 +143,17 @@ defmodule Main do
   end
 
   # 行数指定文字列複数行読み込み
-  # Args: n (integer) - 読み込む行数
-  # Returns: [String.t]
+  @spec read_string_lines(integer) :: [String.t]
   # in:
   # rikka
   # akane
   # namiko
-  # out:
+  # out: (n=3)
   # ["rikka", "akane", "namiko"]
-  defmacro read_string_lines(n) do
-    quote do
-      {__result__, __rest__} = Enum.split(get_input(), unquote(n))
-      update_input(__rest__)
-      __result__
-    end
+  def read_string_lines(n) do
+    {result, rest} = Enum.split(get_input(), n)
+    update_input(rest)
+    result
   end
 
   # 行数指定整数複数行読み込み

--- a/atcoder-cli-nodejs/elixir/Main.ex
+++ b/atcoder-cli-nodejs/elixir/Main.ex
@@ -46,19 +46,21 @@ defmodule Main do
     quote do: Process.put(:input, unquote(new_input))
   end
 
-  # 文字列1行読み込み
-  # Returns: String.t
-  # in:
-  # rikka
-  # out:
-  # "rikka"
-  defmacro read_string do
+  defmacro pop_line do
     quote do
       [__result__ | __rest__] = get_input()
       Process.put(:input, __rest__)
       __result__
     end
   end
+
+  # 文字列1行読み込み
+  @spec read_string() :: String.t
+  # in:
+  # rikka
+  # out:
+  # "rikka"
+  def read_string, do: pop_line()
 
   # 整数1行読み込み
   @spec read_integer() :: integer
@@ -89,19 +91,17 @@ defmodule Main do
   end
 
   # 文字列全行読み込み
-  # Returns: [String.t]
+  @spec read_string_lines() :: [String.t]
   # in:
   # rikka
   # akane
   # namiko
   # out:
   # ["rikka", "akane", "namiko"]
-  defmacro read_string_lines do
-    quote do
-      __all_input__ = get_input()
-      update_input([])
-      __all_input__
-    end
+  def read_string_lines do
+    all_input = get_input()
+    update_input([])
+    all_input
   end
 
   # 整数全行読み込み
@@ -143,20 +143,17 @@ defmodule Main do
   end
 
   # 行数指定文字列複数行読み込み
-  # Args: n (integer) - 読み込む行数
-  # Returns: [String.t]
+  @spec read_string_lines(integer) :: [String.t]
   # in:
   # rikka
   # akane
   # namiko
-  # out:
+  # out: (n=3)
   # ["rikka", "akane", "namiko"]
-  defmacro read_string_lines(n) do
-    quote do
-      {__result__, __rest__} = Enum.split(get_input(), unquote(n))
-      update_input(__rest__)
-      __result__
-    end
+  def read_string_lines(n) do
+    {result, rest} = Enum.split(get_input(), n)
+    update_input(rest)
+    result
   end
 
   # 行数指定整数複数行読み込み


### PR DESCRIPTION
## Summary

Issue #123 で指摘された定義順の問題を解決するため、`read_string` と `read_string_lines` をマクロから関数に変換しました。

## Changes

- `pop_line` マクロを復活させる（内部ヘルパーとして）
- `read_string` をマクロから関数に変換し、内部で `pop_line` マクロを呼び出す
- `read_string_lines/0` と `read_string_lines/1` をマクロから関数に変換
- 適切な `@spec` 型指定を追加

## Benefits

- **定義順の柔軟性**: 関数なので定義順に制約がなくなりました
- **型指定のサポート**: `@spec` による型情報を提供できます
- **パフォーマンス維持**: 内部的に `pop_line` マクロを使用しているため、パフォーマンスは維持されます
- **テストのしやすさ**: 関数なのでテストが容易になります

## Testing

- `elixirc` によるコンパイルチェック完了（エラーなし）
- 両ファイル（`atcoder-cli-nodejs/elixir/Main.ex` と `atcoder-cli-nodejs/all/Main.ex`）に同じ変更を適用

Fixes #123