### PR TITLE
Replace oj s with clipboard copy + browser open in am s command

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,7 @@
 				"terminal.integrated.defaultProfile.linux": "bash",
 				"terminal.integrated.fontSize": 14,
 				"terminal.integrated.fontFamily": "HackGen, 'BIZ UDPGothic', Meiryo, 'Hiragino Kaku Gothic ProN', 'SF Mono', Consolas, monospace",
-				"terminal.integrated.osc52": "always",
+				"terminal.integrated.osc52": "copy",
 				//"workbench.colorTheme": "Default Light+",
 				"window.zoomLevel": 0,
 				// Java settings - override host settings for container

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,7 @@
 				"terminal.integrated.defaultProfile.linux": "bash",
 				"terminal.integrated.fontSize": 14,
 				"terminal.integrated.fontFamily": "HackGen, 'BIZ UDPGothic', Meiryo, 'Hiragino Kaku Gothic ProN', 'SF Mono', Consolas, monospace",
+				"terminal.integrated.osc52": "always",
 				//"workbench.colorTheme": "Default Light+",
 				"window.zoomLevel": 0,
 				// Java settings - override host settings for container

--- a/lib/.support/makefile
+++ b/lib/.support/makefile
@@ -232,7 +232,7 @@ tf: $(TARGET) test/sample-1.in
 	$(OJ) t $(OJ_TFLAGS) $(OJ_TFLAGS_FLOAT)
 
 s: $(TARGET)
-	@printf "\033]52;c;$$(base64 -w 0 < $(SRC))\a"
+	@printf "\033]52;c;$$(base64 < $(SRC) | tr -d '\n\r')\033\134"
 	@echo "$(SRC) をクリップボードにコピーしました"
 	@SUBMIT_URL=$$(echo $(TASK_URL) | sed 's|/tasks/\(.*\)|/submit?taskScreenName=\1|'); \
 	$(OPEN) "$${SUBMIT_URL}"

--- a/lib/.support/makefile
+++ b/lib/.support/makefile
@@ -232,7 +232,11 @@ tf: $(TARGET) test/sample-1.in
 	$(OJ) t $(OJ_TFLAGS) $(OJ_TFLAGS_FLOAT)
 
 s: $(TARGET)
-	$(OJ) s $(TASK_URL) $(SRC) $(OJ_SFLAGS)
+	@printf "\033]52;c;$$(base64 -w 0 < $(SRC))\a"
+	@echo "$(SRC) をクリップボードにコピーしました"
+	@SUBMIT_URL=$$(echo $(TASK_URL) | sed 's|/tasks/\(.*\)|/submit?taskScreenName=\1|'); \
+	$(OPEN) "$${SUBMIT_URL}"
+	@echo "提出ページを開きました。Ctrl+V (Cmd+V) でコードを貼り付けて提出してください"
 
 run: $(TARGET)
 	$(RUN_TEST)

--- a/lib/.support/makefile
+++ b/lib/.support/makefile
@@ -234,7 +234,7 @@ tf: $(TARGET) test/sample-1.in
 s: $(TARGET)
 	@printf "\033]52;c;$$(base64 < $(SRC) | tr -d '\n\r')\033\134"
 	@echo "$(SRC) をクリップボードにコピーしました"
-	@SUBMIT_URL=$$(echo $(TASK_URL) | sed 's|/tasks/\(.*\)|/submit?taskScreenName=\1|'); \
+	@SUBMIT_URL=$$(printf '%s\n' "$(TASK_URL)" | sed 's|/tasks/\(.*\)|/submit?taskScreenName=\1|'); \
 	$(OPEN) "$${SUBMIT_URL}"
 	@echo "提出ページを開きました。Ctrl+V (Cmd+V) でコードを貼り付けて提出してください"
 

--- a/lib/.support/makefile
+++ b/lib/.support/makefile
@@ -234,8 +234,7 @@ tf: $(TARGET) test/sample-1.in
 s: $(TARGET)
 	@printf "\033]52;c;$$(base64 < $(SRC) | tr -d '\n\r')\033\134"
 	@echo "$(SRC) をクリップボードにコピーしました"
-	@SUBMIT_URL=$$(printf '%s\n' "$(TASK_URL)" | sed 's|/tasks/\(.*\)|/submit?taskScreenName=\1|'); \
-	$(OPEN) "$${SUBMIT_URL}"
+	@$(OPEN) "$$(printf '%s\n' "$(TASK_URL)" | sed 's|/tasks/\(.*\)|/submit?taskScreenName=\1|')"
 	@echo "提出ページを開きました。Ctrl+V (Cmd+V) でコードを貼り付けて提出してください"
 
 run: $(TARGET)


### PR DESCRIPTION
## Summary
- `am s` コマンドの `oj s` による提出を、OSC 52 クリップボードコピー + ブラウザで提出ページオープンに変更
- `devcontainer.json` に `terminal.integrated.osc52: "always"` 設定を追加

## Changes

### `lib/.support/makefile`
- `s` ターゲットの `oj s` コマンドを以下に置換:
  1. OSC 52 エスケープシーケンスでソースコードをホスト OS のクリップボードにコピー
  2. TASK_URL から提出ページ URL を構築してブラウザで開く
  3. ユーザーへの案内メッセージを表示

### `.devcontainer/devcontainer.json`
- VS Code の OSC 52 クリップボード連携を有効化 (`terminal.integrated.osc52: "always"`)

## New workflow
```
am s .java
  ↓
1. Main.java の内容がクリップボードにコピーされる
2. AtCoder 提出ページがブラウザで開く (タスク選択済み)
3. ユーザーが Ctrl+V / Cmd+V で貼り付けて提出
```

resolve #126

## Test plan
- [ ] Dev Container 内で `am s .java` 実行時にクリップボードにコードがコピーされることを確認
- [ ] 提出ページ URL が正しく構築されブラウザで開くことを確認
- [ ] 各言語 (.java, .py, .cpp, .rb, .ex, .js, .rs, .erl, .php) で動作確認